### PR TITLE
Add "network" and "remove_in_cleanup" columns

### DIFF
--- a/knexfile.js
+++ b/knexfile.js
@@ -1,0 +1,66 @@
+
+const path = require("path");
+const dbPath = path.join(__dirname, 'src/db.js');
+const { myConfig } = require(dbPath);
+
+const enableSSL = myConfig.DB_HOSTIP !== 'localhost';
+
+// TODO: we can review the various environments below
+module.exports = {
+  development: {
+    client: 'postgresql',
+    connection: {
+      user: myConfig.DB_USER,
+      password: myConfig.DB_PASS,
+      database: myConfig.DB_NAME,
+      host: myConfig.DB_HOSTIP,
+      port: myConfig.DB_HOSTPORT,
+      ssl: enableSSL
+    },
+    pool: {
+      min: 2,
+      max: 10
+    },
+    migrations: {
+      tableName: 'knex_migrations'
+    }
+  },
+
+  staging: {
+    client: 'postgresql',
+    connection: {
+      user: myConfig.DB_USER,
+      password: myConfig.DB_PASS,
+      database: myConfig.DB_NAME,
+      host: myConfig.DB_HOSTIP,
+      port: myConfig.DB_HOSTPORT,
+      ssl: enableSSL
+    },
+    pool: {
+      min: 2,
+      max: 10
+    },
+    migrations: {
+      tableName: 'knex_migrations'
+    }
+  },
+
+  production: {
+    client: 'postgresql',
+    connection: {
+      user: myConfig.DB_USER,
+      password: myConfig.DB_PASS,
+      database: myConfig.DB_NAME,
+      host: myConfig.DB_HOSTIP,
+      port: myConfig.DB_HOSTPORT,
+      ssl: enableSSL
+    },
+    pool: {
+      min: 2,
+      max: 10
+    },
+    migrations: {
+      tableName: 'knex_migrations'
+    }
+  }
+};

--- a/migrations/20220109042709_add_network_generated_flag.js
+++ b/migrations/20220109042709_add_network_generated_flag.js
@@ -1,0 +1,17 @@
+const path = require("path");
+const dbPath = path.join(__dirname, '../src/db.js');
+const { myConfig } = require(dbPath);
+
+exports.up = function(knex) {
+  return knex.schema.table(myConfig.DB_TABLENAME_ROLES, function(table) {
+    table.string('network').defaultTo("mainnet");
+    table.boolean('remove_in_cleanup')
+  })
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(myConfig.DB_TABLENAME_ROLES, function(table) {
+    table.dropColumn('network')
+    table.dropColumn('remove_in_cleanup')
+  })
+};

--- a/src/discord.js
+++ b/src/discord.js
@@ -9,7 +9,7 @@ const { Client, Intents, MessageEmbed, Permissions, MessagePayload, MessageButto
 const { SlashCommandBuilder } = require('@discordjs/builders');
 const { REST } = require('@discordjs/rest');
 const { Routes } = require('discord-api-types/v9');
-const {myConfig} = require("./db");
+const { myConfig } = require("./db");
 const intents = new Intents([ Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES, Intents.FLAGS.GUILD_MEMBERS, Intents.FLAGS.GUILD_INTEGRATIONS ]);
 const client = new Client({intents: intents })
 
@@ -77,7 +77,6 @@ client.on("guildCreate", async guild => {
 
 	let existingRoles = {}
 	for (let role of existingObjectRoles.values()) {
-		console.log('aloha role', role)
 		existingRoles[role.name] = role.id
 	}
 
@@ -95,8 +94,8 @@ client.on("guildCreate", async guild => {
 	}
 
 	// Add default roles
-	await db.rolesSet(guild.id, finalRoleMapping[desiredRoles[0]], desiredRoles[0], 'native', 'osmo')
-	await db.rolesSet(guild.id, finalRoleMapping[desiredRoles[1]], desiredRoles[1], 'native', 'juno')
+	await db.rolesSet(guild.id, finalRoleMapping[desiredRoles[0]], desiredRoles[0], 'native', 'osmo', 'mainnet', true)
+	await db.rolesSet(guild.id, finalRoleMapping[desiredRoles[1]], desiredRoles[1], 'native', 'juno', 'mainnet', true)
 })
 
 let commands = [


### PR DESCRIPTION
Fixes #4 

Eventually we're going to need to modify the database in a way that's not destructive. I looked a bit into using migrations for the library we're currently using for database stuff called knex.

I've used their system to add a migration file, included in this PR.

On the Render side, we can see I've added a command to be build part, which will tells knex to run through all the migration files it hasn't applied yet.

<img width="1025" alt="Screen Shot 2022-01-09 at 8 30 33 PM" src="https://user-images.githubusercontent.com/1042667/148718933-0216685c-165e-4b1f-83b1-ea9092704a11.png">

This adds two columns:

1. `network` meaning `mainnet` or `testnet` basically
2. `remove_in_cleanup` which is a bool, indicating whether we should remove this row when we eventually add a slash command to have StarryBot leave the guild.