### PR TITLE
Fix: Pass string into setFooter correctly for token-rule add flow

### DIFF
--- a/src/wizard/add-token-rule.js
+++ b/src/wizard/add-token-rule.js
@@ -226,7 +226,7 @@ function createStep1(userId, parentWizard) {
             inline: true
           }
         ])
-          .setFooter({text: "🎗️ When you're finished creating your cw20 token, please type the address in this channel."})
+          .setFooter("🎗️ When you're finished creating your cw20 token, please type the address in this channel.")
         ]
       });
     },
@@ -277,7 +277,7 @@ function createStep2(userId, parentWizard) {
           .setColor('#FDC2A0')
           .setTitle('How many tokens?')
           .setDescription('Please enter the number of tokens a user must have to get a special role.')
-          .setFooter({text: 'Note: this role will be created automatically'}) ]
+          .setFooter('Note: this role will be created automatically') ]
       });
     },
     async({ interaction }, ...extra) => {


### PR DESCRIPTION
```
The MessageEmbed.setFooter function requires a string value for
the first parameter and additional options after. With the object
instead, this was failing to display the message at all.
```

Screenshot of this working:
![Screen Shot 2022-01-26 at 8 43 46 PM](https://user-images.githubusercontent.com/50123991/151293429-1be81ac1-ea87-489c-ba89-d5ad8a9fcfaf.png)

For comparison, we already do this for the message embed here: https://github.com/starryzone/starrybot-discord/blob/main/src/discord.js#L119