### PR TITLE
Fix: Return role name in map correctly to fix welcome embed list

### DIFF
--- a/src/discord.js
+++ b/src/discord.js
@@ -125,7 +125,7 @@ function createEmbed(traveller, saganism) {
 
 async function printWelcomeMessage(guild) {
 	const systemChannelId = guild.systemChannelId;
-	let desiredRolesForMessage = desiredRoles.map(role=>{role.name}).join('\n- ')
+	let desiredRolesForMessage = desiredRoles.map(role => role.name).join('\n- ')
 	let systemChannel = await client.channels.fetch(systemChannelId);
 	const embed = new MessageEmbed()
 		.setColor('#0099ff')


### PR DESCRIPTION
Javascript automatically returns whatever is after the => if the
function is within a single line. With the brackets there, it'll
treat whatever is within the brackets as a function instead, and
expect it to contain a "return"; as a result, each loop of the current
map returns nothing and we have whitespace joined.

Before:

![Screen Shot 2022-01-26 at 9 03 59 PM](https://user-images.githubusercontent.com/50123991/151295213-ae24a73e-a538-44a6-afd0-a85a82006722.png)

After (on this branch):

![Screen Shot 2022-01-26 at 9 04 10 PM](https://user-images.githubusercontent.com/50123991/151295232-30fa5854-8e03-4b69-a61b-862b66f44274.png)

