### PR TITLE
Fix: Check existing roles correctly so we don't re-add existing roles

### DIFF
--- a/src/discord.js
+++ b/src/discord.js
@@ -161,7 +161,8 @@ async function guildCreate(guild) {
 	let existingRoles =	await guild.roles.fetch();
 	for(let i = 0;i<desiredRoles.length;i++) {
 		let role = desiredRoles[i]
-		if(!existingRoles.hasOwnProperty(role.name)) {
+		// See if we can find an existing role with the same name.
+		if(!existingRoles.find(existingRole => existingRole.name === role.name)) {
 			await guild.roles.create({name: role.name, position: 0})
 		}
 		await db.rolesSet(guild.id,role.name,role.type,role.address,role.net,true,client.user.id,1);


### PR DESCRIPTION
```
The guild.roles.fetch promise resolves with a Collection class of their
Role object. Although they support has instead of hasOwnProperty, they
use the ID for keys instead of the role names that we check here.

Instead, we'll use their .find helper to make sure we can't find
a role with the same name before trying to create it.
```

tl;dr - if you add the bot twice, you should only have 2 roles added, not 4.

https://user-images.githubusercontent.com/50123991/151302303-1f9529ef-4117-4513-bd6c-5cb8ba88191d.mov



Documentation on guild.roles.fetch here: https://discord.js.org/#/docs/discord.js/stable/class/RoleManager?scrollTo=fetch

Documentation on Discord's Collection.find here: https://discord.js.org/#/docs/collection/main/class/Collection?scrollTo=find

