### PR TITLE
Fix: Update handleCW20Entry for new testnet URL

### DIFF
--- a/src/commands/steps/handleCW20Entry.js
+++ b/src/commands/steps/handleCW20Entry.js
@@ -14,41 +14,43 @@ async function handleCW20Entry(req, res, ctx, next) {
   let network = 'mainnet'
   let cw20Input, tokenInfo, cosmClient, daoInfo
 
+  const userInput = interaction.content;
   // If user has done something else (like emoji reaction) do nothing
-  if (!interaction.content) return;
+  if (!userInput) return;
 
   try {
-    // TODO: add another check for https://testnet.daodao.zone to determine network
-    if (interaction.content.startsWith('https://daodao.zone')) {
-      cosmClient = await CosmWasmClient.connect(JUNO_MAINNET_RPC_ENDPOINT)
-      daoInfo = await checkForDAODAODAO(res, cosmClient, interaction.content, true)
-      if (daoInfo === false) {
-        network = 'testnet'
-        cosmClient = await CosmWasmClient.connect(JUNO_TESTNET_RPC_ENDPOINT)
-        daoInfo = await checkForDAODAODAO(res, cosmClient, interaction.content, false)
-      }
-
+    const daodaoRegex = /^https:\/\/(testnet\.)?daodao.zone/;
+    if (userInput.match(daodaoRegex)) {
+      network = userInput.includes('testnet') ? 'testnet' : 'mainnet';
+      cosmClient = network === 'mainnet' ?
+        await CosmWasmClient.connect(JUNO_MAINNET_RPC_ENDPOINT) :
+        await CosmWasmClient.connect(JUNO_TESTNET_RPC_ENDPOINT);
+      // Exit a failed state more gracefully on mainnet
+      const gracefulExit = network === 'mainnet';
+      daoInfo = await checkForDAODAODAO(cosmClient, userInput, gracefulExit);
       // If there isn't a governance token associated with this DAO, fail with message
       if (!daoInfo || !daoInfo.hasOwnProperty('gov_token')) {
-        return await res.error("We couldn't find any governance token associated with your DAO :/\nPerhaps destroyed in a supernova?");
+        // This will be caught in our own catch below
+        throw "We couldn't find any governance token associated with your DAO :/\nPerhaps destroyed in a supernova?";
       }
       cw20Input = daoInfo['gov_token']
       // Now that we have the cw20 token address and network, get the info we want
-      tokenInfo = await checkForCW20(res, cosmClient, cw20Input, false)
+      tokenInfo = await checkForCW20(cosmClient, cw20Input, false)
     } else {
       // Check user's cw20 token for existence on mainnet then testnet
-      cw20Input = interaction.content;
+      cw20Input = userInput;
       cosmClient = await CosmWasmClient.connect(JUNO_MAINNET_RPC_ENDPOINT)
-      tokenInfo = await checkForCW20(res, cosmClient, cw20Input, true)
+      tokenInfo = await checkForCW20(cosmClient, cw20Input, true)
       if (tokenInfo === false) {
         // Nothing was found on mainnet, try testnet
         network = 'testnet'
         cosmClient = await CosmWasmClient.connect(JUNO_TESTNET_RPC_ENDPOINT)
-        tokenInfo = await checkForCW20(res, cosmClient, cw20Input, false)
+        tokenInfo = await checkForCW20(cosmClient, cw20Input, false)
       }
     }
   } catch (e) {
-    return await res.error(e, `Sorry, something went wrong. Please try again.`);
+    // Notify the channel with whatever went wrong in this step
+    return await res.error(e);
   }
 
   ctx.cw20 = cw20Input;

--- a/src/token.js
+++ b/src/token.js
@@ -1,51 +1,64 @@
 // This will check mainnet or testnet for the existence and balance of the cw20 contract
 // gracefulExit is useful when we check if it's on mainnet first, then testnet.
 //   if it's not on mainnet, we don't want it to fail, basically
-const checkForCW20 = async (res, cosmClient, cw20Input, gracefulExit) => {
+const checkForCW20 = async (cosmClient, cw20Input, gracefulExit) => {
   let tokenInfo
   try {
     tokenInfo = await cosmClient.queryContractSmart(cw20Input, {
       token_info: { },
     })
   } catch (e) {
-    const chainId = await cosmClient.getChainId()
+    let chainId;
+    try {
+      // It's possible for this to also fail, but we still want to know what went wrong
+      chainId = await cosmClient.getChainId();
+    }  catch (e) {
+      chainId = '[chain ID not found]'
+    }
     tokenInfo = false
     console.error(`Error message after trying to query cw20 on ${chainId}`, e.message)
     if (e.message.includes('decoding bech32 failed')) {
-      return await res.error('Invalid address. Remember: first you copy, then you paste.');
+      throw 'Invalid address. Remember: first you copy, then you paste.';
     } else if (e.message.includes('contract: not found')) {
       if (gracefulExit) return false
-      return await res.error('No contract at that address. Potential black hole.');
+      throw 'No contract at that address. Potential black hole.';
     } else if (e.message.includes('Error parsing into type')) {
       if (gracefulExit) return false
-      return await res.error('That is a valid contract, but cosmic perturbations tell us it is not a cw20.');
+      throw 'That is a valid contract, but cosmic perturbations tell us it is not a cw20.';
     }
   }
   return tokenInfo
 }
 
-const checkForDAODAODAO = async (res, cosmClient, daoDAOUrl, gracefulExit) => {
+const checkForDAODAODAO = async (cosmClient, daoDAOUrl, gracefulExit) => {
   let daoInfo
   try {
-    const splitUrl = daoDAOUrl.split('/')
-    const daoAddress = splitUrl[splitUrl.length -1]
-    console.log('daoAddress', daoAddress)
+    const daoAddressRegex = /^https:\/\/(testnet\.)?daodao.zone\/dao\/(\w*)/;
+    const regexMatches = daoAddressRegex.exec(daoDAOUrl);
+    // [0] is the string itself, [1] is the (testnet\.) capture group, [2] is the (\w*) capture group
+    const daoAddress = regexMatches[2];
     daoInfo = await cosmClient.queryContractSmart(daoAddress, {
       get_config: { },
     })
     console.log('daoInfo', daoInfo)
   } catch (e) {
-    const chainId = await cosmClient.getChainId()
+    let chainId;
+    try {
+      // It's possible for this to also fail, but we still want to know what went wrong
+      chainId = await cosmClient.getChainId();
+    }  catch (e) {
+      chainId = '[chain ID not found]'
+    }
     console.error(`Error message after trying to query daodao dao on ${chainId}`, e.message)
     // TODO: reduce copy pasta
     if (e.message.includes('decoding bech32 failed')) {
-      return await res.error('Invalid address. Remember: first you copy, then you paste.');
+      throw 'Invalid address. Remember: first you copy, then you paste.';
     } else if (e.message.includes('contract: not found')) {
       if (gracefulExit) return false
-      return await res.error('No contract at that address. Probable black hole.');
+      throw 'No contract at that address. Probable black hole.';
     } else if (e.message.includes('Error parsing into type')) {
       if (gracefulExit) return false
-      return await res.error('That is a valid contract, but cosmic perturbations tell us it is not a cw20.');
+      throw 'That is a valid contract, but cosmic perturbations tell us it is not a cw20.';
     }
   }
   return daoInfo


### PR DESCRIPTION
### Description:
```
The URL for daodao's testnet is now testnet.daodao.zone, which
breaks our handleCW20Entry and checkForDAODAODAO logic, which was
expecting the daodao URL to always look a certain way.

Both of these cases now use regexes instead. This also updates
the functions in token to throw their errors again, and rely on the
step calling them to call res.error more correctly in the catch
function.
```

Credit to [regex101](https://regex101.com/) for helping me with the regex we wanted here:
![image](https://user-images.githubusercontent.com/50123991/153739787-088fdd9b-13b4-466d-9544-e8fb5c5a1296.png)


### Suggested QA:

- [ ] Use `/starry farewell` to remove bot, ensure that created roles have been removed
- [ ] Re-add the bot, expect a welcome message
- [ ] Use `/starry token-rule add` normally
  - [ ] Select "Choose a token" normally
  - [ ] Select "I need to make a token" normally
  - [ ] Select the DAODAO option normally
- [ ] Use `/starry token-rule add` incorrectly, expect helpful error
  - [ ] For the first two options, enter invalid cw20 address
  - [ ] For DAODAO option, type in an incorrect URL
- [ ] Use `starry join` flow from an account that *doesn't* have the added token, expect no roles when finished
- [ ] Use `starry join` flow from an account that *does* have the added token, expect all applicable roles to be added

### Further QA:

- [ ] In the middle of a wizard, click on a button from another step, expect a helpful error or it to be ignored
- [ ] Reply to messages that are expecting emoji reaction inputs
- [ ] Kick starrybot (not farewell) and re-add, ensuring normal functioning
