### PR TITLE
✨ Add new tokenList command to list the token rules per guild

### DIFF
--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -3,6 +3,7 @@ const { SlashCommandBuilder } = require('@discordjs/builders');
 const { starryCommandFarewell } = require('./farewell');
 const { starryCommandJoin } = require('./join');
 const { starryCommandTokenAdd } = require('./tokenAdd');
+const { starryCommandTokenList } = require('./tokenList');
 // TODO: we'll add this in later
 // const { starryCommandTokenEdit } = require('./tokenEdit');
 const { starryCommandTokenRemove } = require('./tokenRemove');
@@ -21,6 +22,7 @@ const definedCommands = [
     options: [
       starryCommandTokenAdd,
       // starryCommandTokenEdit,
+      starryCommandTokenList,
       starryCommandTokenRemove
     ]
   },

--- a/src/commands/tokenList.js
+++ b/src/commands/tokenList.js
@@ -1,0 +1,30 @@
+const { rolesGet } = require("../db");
+const { createEmbed } = require("../utils/messages");
+
+async function starryCommandTokenList(req, res, ctx, next) {
+  const { interaction } = req;
+  let roles = await rolesGet(interaction.guildId);
+  const title = `${roles.length} roles found`;
+  const description = roles.length > 0 ?
+    `${roles.map(role => {
+        const roleName = role.give_role;
+        const roleAmt = role.has_minimum_of;
+        return `-${roleName} (min: ${roleAmt})\n`;
+      }).join('')}` :
+    `This will be way more exciting when roles are added :)`;
+
+  interaction.reply({
+    embeds: [
+      createEmbed({ title, description })
+    ]
+  })
+  res.done();
+}
+
+module.exports = {
+  starryCommandTokenList: {
+    name: 'list',
+    description: 'List all token rules for this guild',
+    execute: starryCommandTokenList,
+  }
+}


### PR DESCRIPTION
Fixes #12 

### Description:

Use `/starry token-rule list` 😄 

![Screen Shot 2022-02-12 at 9 49 22 PM](https://user-images.githubusercontent.com/50123991/153740670-b30f7202-68cf-468c-a8ec-7e0545a57df3.png)


### Suggested QA:

- [ ] Use `/starry farewell` to remove bot, ensure that created roles have been removed
- [ ] Re-add the bot, expect a welcome message
- [ ] Use `/starry token-rule add` normally
  - [ ] Select "Choose a token" normally
  - [ ] Select "I need to make a token" normally
  - [ ] Select the DAODAO option normally
- [ ] Use `/starry token-rule add` incorrectly, expect helpful error
  - [ ] For the first two options, enter invalid cw20 address
  - [ ] For DAODAO option, type in an incorrect URL
- [ ] Use `starry join` flow from an account that *doesn't* have the added token, expect no roles when finished
- [ ] Use `starry join` flow from an account that *does* have the added token, expect all applicable roles to be added

### Further QA:

- [ ] In the middle of a wizard, click on a button from another step, expect a helpful error or it to be ignored
- [ ] Reply to messages that are expecting emoji reaction inputs
- [ ] Kick starrybot (not farewell) and re-add, ensuring normal functioning
