### PR TITLE
✨ Add new health command to run bot diagnostics

### DIFF
--- a/src/commands/health.js
+++ b/src/commands/health.js
@@ -1,0 +1,106 @@
+const { CosmWasmClient } = require("@cosmjs/cosmwasm-stargate");
+const { rolesGet } = require("../db");
+const { networkInfo } = require("../logic");
+const { createEmbed } = require("../utils/messages");
+
+async function checkNetwork (networkName, networkUrl) {
+  const prefix = `${networkName} status:`
+  try {
+    await CosmWasmClient.connect(networkUrl);
+    return `${prefix} 🟢`;
+  } catch (e) {
+    console.warn(`Could not connect to ${networkUrl} for ${networkName}`, e);
+    return `${prefix} 🔴`;
+  }
+};
+
+async function checkAllNetworks () {
+  // Loop through all of our networks
+  let networkPromises = [];
+  Object.keys(networkInfo).forEach(networkName => {
+    const network = networkInfo[networkName];
+    if (network.mainnet) {
+      networkPromises.push(checkNetwork(networkName + ' (mainnet)', network.mainnet));
+    }
+    if (network.testnet) {
+      networkPromises.push(checkNetwork(networkName + ' (testnet)', network.testnet));
+    }
+  });
+  return await Promise.all(networkPromises);
+};
+
+async function checkAllPermissions(guild) {
+  const allDBRoles = await rolesGet(guild.id);
+  const allDiscordRoles = await guild.roles.fetch();
+
+  if (allDBRoles.length === 0) {
+    return [`No token rules yet!`];
+  }
+
+  const permissionPromises = allDBRoles.map(async role => {
+    const prefix = `${role.give_role} status:`;
+    const existingRole = allDiscordRoles.find(discordRole => discordRole.name === role.give_role);
+
+    // We have a record of a role they may have deleted.
+    // Just add it and let them know.
+    if (!existingRole) {
+      await guild.roles.create({name: role.give_role, position: 0});
+      return `${prefix} 🟢 (role was missing, but now fixed)`;
+    }
+
+    // Try to "edit" the role with the same name - if we fail,
+    // it means we don't have the permission to give it to someone else either
+    try {
+      await guild.roles.edit(existingRole, { name: role.give_role})
+      return `${prefix} 🟢`;
+    } catch (e) {
+      if (e?.message && e.message.includes('Missing Permissions')) {
+        return `${prefix} 🔴 (permissions are not high enough)`;
+      } else {
+        return `${prefix} 🔴`;
+      }
+    }
+  });
+  return await Promise.all(permissionPromises);
+};
+
+async function starryCommandHealth(req, res, ctx, next) {
+	const { interaction } = req;
+  const { guild } = interaction;
+  const networkResults = await checkAllNetworks();
+  const permissionsResults = await checkAllPermissions(guild);
+
+  await interaction.reply({
+    embeds: [
+      createEmbed({
+        color: '#7585FF',
+        title: 'Diagnostics results 🌟',
+        description: 'This info describes what starrybot needs to work correctly',
+        fields: [
+          // Shouldn't be possible for these two arrays to be empty, but
+          // the message won't send at all if this value is undefined
+          {
+            name: 'Network statuses',
+            value: networkResults.join('\n') || '',
+          },
+          {
+            name: 'Role permissions',
+            value: permissionsResults.join('\n') || '',
+          },
+        ],
+        footer: `If there are any 🔴 above, please note that starrybot may not work as expected!`,
+      })
+    ]
+  })
+
+  res.done();
+}
+
+module.exports = {
+  starryCommandHealth: {
+    adminOnly: true,
+    name: 'health',
+    description: 'Run diagnostics for starrybot',
+    execute: starryCommandHealth,
+  }
+}

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
 
 const { starryCommandFarewell } = require('./farewell');
+const { starryCommandHealth } = require('./health');
 const { starryCommandJoin } = require('./join');
 const { starryCommandTokenAdd } = require('./tokenAdd');
 // TODO: we'll add this in later
@@ -24,6 +25,7 @@ const definedCommands = [
       starryCommandTokenRemove
     ]
   },
+  starryCommandHealth,
   starryCommandJoin,
   starryCommandFarewell,
 ];


### PR DESCRIPTION
```
The /starry health command now quickly checks for 2 things:

- Whether or not we're able to connect to every network's
  configured rpc endpoints via CosmWasmClient
- Whether or not we're able to edit every role associated
  with this guild

The results of every check are listed in the channel
```

### Description:

Use `/starry health` 😄 

![Screen Shot 2022-02-13 at 12 09 25 AM](https://user-images.githubusercontent.com/50123991/153744676-a342a7ab-04b4-4448-bdd9-69e9ac6a0813.png)

For:
![Screen Shot 2022-02-13 at 12 09 44 AM](https://user-images.githubusercontent.com/50123991/153744692-f63608d9-e17b-4bc5-98bf-c851c1f3acf3.png)

### Suggested QA:

- [ ] Use `/starry farewell` to remove bot, ensure that created roles have been removed
- [ ] Re-add the bot, expect a welcome message
- [ ] Use `/starry token-rule add` normally
  - [ ] Select "Choose a token" normally
  - [ ] Select "I need to make a token" normally
  - [ ] Select the DAODAO option normally
- [ ] Use `/starry token-rule add` incorrectly, expect helpful error
  - [ ] For the first two options, enter invalid cw20 address
  - [ ] For DAODAO option, type in an incorrect URL
- [ ] Use `starry join` flow from an account that *doesn't* have the added token, expect no roles when finished
- [ ] Use `starry join` flow from an account that *does* have the added token, expect all applicable roles to be added

### Further QA:

- [ ] In the middle of a wizard, click on a button from another step, expect a helpful error or it to be ignored
- [ ] Reply to messages that are expecting emoji reaction inputs
- [ ] Kick starrybot (not farewell) and re-add, ensuring normal functioning
