### PR TITLE
add LCD endpoints + health check, ensure cw20 network is found

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -7,8 +7,10 @@ PORT=8080
 # Where to validate a user's wallet
 VALIDATOR=https://verify.starrybot.xyz
 
-# RPC endpoints for checking tokens
-COSMOS_NETWORKS='{"juno": { "mainnet": "https://rpc-juno.itastakers.com", "testnet": "https://rpc.uni.juno.deuslabs.fi" }, "stars": { "mainnet": "https://rpc.stargaze-apis.com", "testnet": "https://rpc.devnet.publicawesome.dev" }}'
+# RPC and LCD endpoints for checking tokens and delegations
+COSMOS_NETWORKS='{ "juno": { "rpc": { "mainnet": "https://rpc-juno.itastakers.com", "testnet": "https://rpc.uni.juno.deuslabs.fi" }, "lcd": { "mainnet": "https://juno.stakesystems.io" } }, "stars": { "rpc": { "mainnet": "https://rpc.stargaze-apis.com", "testnet": "https://rpc.devnet.publicawesome.dev" }, "lcd": { "mainnet": "https://api.stars.kingnodes.com" } } }'
+
+# /staking/delegators/stars18zl54ww7yhe88zesr0genfvc65q7ke4jjcmgf5/delegations
 
 # Database connection variables
 # DB_CONNECTIONNAME=

--- a/package.json
+++ b/package.json
@@ -5,15 +5,16 @@
 	"license": "MIT",
 	"description": "starrybot helps users join membership-enabled Discord rooms",
 	"main": "server.js",
-	"contributors": [{
-		"name": "@anselm"
-	},
-	{
-		"name": "@mikedotexe"
-	},
-	{
-		"name": "@sudovickili"
-	}
+	"contributors": [
+		{
+			"name": "@anselm"
+		},
+		{
+			"name": "@mikedotexe"
+		},
+		{
+			"name": "@sudovickili"
+		}
 	],
 	"repository": "https://github.com/starryzone/starrybot-discord.git",
 	"engines": {
@@ -34,6 +35,7 @@
 		"dotenv": "^14.3.2",
 		"express": "^4.17.1",
 		"knex": "^0.95.14",
+		"node-fetch": "^2.6.6",
 		"pg": "^8.7.1",
 		"web-vitals": "^1.0.1",
 		"winston": "^3.1.0"

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -118,7 +118,7 @@ async function initiateCommandChain(firstCommandName, interaction) {
           createEmbed({
             color: '#be75a4',
             title: 'Error (star might be in retrograde)',
-            description: channelError || consoleError,
+            description: channelError ? channelError.toString() : consoleError.toString(),
           })
         ],
         ephemeral: true,

--- a/src/commands/steps/daoDao.js
+++ b/src/commands/steps/daoDao.js
@@ -7,7 +7,7 @@ async function daoDao(req, res, ctx, next) {
       createEmbed({
         color: '#FDC2A0',
         title: 'Check out DAODAO',
-        description: "If you haven't set up a DAO, visit the link above to create a DAO with a governance token.",
+        description: 'If you have not set up a DAO, visit the link above to create a DAO with a governance token.',
         fields: [
           {
             name: '🧑‍🤝‍🧑', // a big space

--- a/src/commands/tokenList.js
+++ b/src/commands/tokenList.js
@@ -10,7 +10,7 @@ async function starryCommandTokenList(req, res, ctx, next) {
         const roleName = role.give_role;
         const roleAmt = role.has_minimum_of;
         const roleDecimals = role.decimals;
-        return `-${roleName} (min: ${(roleAmt / (10 ** roleDecimals)) })\n`;
+        return `★ ${roleName} (min: ${(roleAmt / (10 ** roleDecimals)) })\n`;
       }).join('')}` :
     `This will be way more exciting when roles are added :)`;
 

--- a/src/token.js
+++ b/src/token.js
@@ -30,13 +30,17 @@ const checkForCW20 = async (cosmClient, cw20Input, gracefulExit) => {
   return tokenInfo
 }
 
+const getDAOAddressFromDAODAOUrl = daoDAOUrl => {
+  const daoAddressRegex = /^https:\/\/(testnet\.)?daodao.zone\/dao\/(\w*)/;
+  const regexMatches = daoAddressRegex.exec(daoDAOUrl);
+  // [0] is the string itself, [1] is the (testnet\.) capture group, [2] is the (\w*) capture group
+  return regexMatches[2];
+}
+
 const checkForDAODAODAO = async (cosmClient, daoDAOUrl, gracefulExit) => {
   let daoInfo
   try {
-    const daoAddressRegex = /^https:\/\/(testnet\.)?daodao.zone\/dao\/(\w*)/;
-    const regexMatches = daoAddressRegex.exec(daoDAOUrl);
-    // [0] is the string itself, [1] is the (testnet\.) capture group, [2] is the (\w*) capture group
-    const daoAddress = regexMatches[2];
+    const daoAddress = getDAOAddressFromDAODAOUrl(daoDAOUrl)
     daoInfo = await cosmClient.queryContractSmart(daoAddress, {
       get_config: { },
     })
@@ -66,5 +70,6 @@ const checkForDAODAODAO = async (cosmClient, daoDAOUrl, gracefulExit) => {
 
 module.exports = {
     checkForCW20,
+    getDAOAddressFromDAODAOUrl,
     checkForDAODAODAO,
 }

--- a/src/utils/networks.js
+++ b/src/utils/networks.js
@@ -1,0 +1,53 @@
+const { Bech32 } = require("@cosmjs/encoding");
+
+// See getNetworkInfo where this is taken from env vars
+let networkInfo, networkPrefixes;
+try {
+  networkInfo = JSON.parse(process.env.COSMOS_NETWORKS)
+  networkPrefixes = Object.keys(networkInfo)
+} catch (e) {
+  console.error('Cannot parse COSMOS_NETWORKS environment variable, please ensure that it is set.')
+}
+
+function getPrefixFromToken(tokenAddress) {
+  let ret;
+  const decodedAccount = Bech32.decode(tokenAddress);
+  if (decodedAccount && decodedAccount.prefix) {
+    ret = decodedAccount.prefix
+  } else {
+    ret = false
+  }
+  return ret
+}
+
+// Note that this function throws, so please call it in a try/catch
+/*
+ * tokenAddress — e.g. "juno1w2sr3vz0xg9kj82kumd7j7a5736wfklqtnctx0frdj26kclctleqvzx2ly"
+ */
+function getConnectionFromToken(tokenAddress, connType, network) {
+    const prefix = getPrefixFromToken(tokenAddress)
+    if (networkPrefixes.includes(prefix)) {
+      return getConnectionFromPrefix(prefix, connType, network)
+    } else {
+      throw 'Could not find prefix'
+    }
+}
+
+// Note that this function throws, so please call it in a try/catch
+/*
+ * prefix — e.g. "stars"
+ * connType — "lcd" | "rpc"
+ * network — "mainnet"
+ */
+function getConnectionFromPrefix(prefix, connType, network) {
+  if (!networkInfo.hasOwnProperty(prefix)) throw 'Do not know about that network prefix'
+  return networkInfo[prefix][connType][network]
+}
+
+module.exports = {
+  getPrefixFromToken,
+  getConnectionFromToken,
+  getConnectionFromPrefix,
+  networkInfo,
+  networkPrefixes
+}


### PR DESCRIPTION
We're going to want to add a new kind of endpoint that's different than the RPC endpoint. This one is called the LCD endpoint.

### Description:

I noticed that in a couple places we were assuming Juno for cw20s, so I put some logic into a new file `utils/networks.js` so we can get prefixes from addresses and determine which network we're connecting to.

Also made some small fixes about a bug that crashes when it tries to pass an object into a message description.

Added more health checks for the LCD systems.

This PR is done so that we can determine how many JUNO someone has liquid but also staked. We'll need the LCD endpoints for that. You can see what this'll look like here:
https://juno.stakesystems.io/staking/delegators/juno18zl54ww7yhe88zesr0genfvc65q7ke4jsk0w9e/delegations

NOTE: we'll need to change the Render environment variable to this:

```
COSMOS_NETWORKS='{ "juno": { "rpc": { "mainnet": "https://rpc-juno.itastakers.com", "testnet": "https://rpc.uni.juno.deuslabs.fi" }, "lcd": { "mainnet": "https://juno.stakesystems.io" } }, "stars": { "rpc": { "mainnet": "https://rpc.stargaze-apis.com", "testnet": "https://rpc.devnet.publicawesome.dev" }, "lcd": { "mainnet": "https://api.stars.kingnodes.com" } } }'
```

### Suggested QA:

- [ ] Use `/starry farewell` to remove bot, ensure that created roles have been removed
- [ ] Re-add the bot, expect a welcome message
- [ ] Use `/starry token-rule add` normally
  - [ ] Select "Choose a token" normally
  - [ ] Select "I need to make a token" normally
  - [ ] Select the DAODAO option normally
- [ ] Use `/starry token-rule add` incorrectly, expect helpful error
  - [ ] For the first two options, enter invalid cw20 address
  - [ ] For DAODAO option, type in an incorrect URL
- [ ] Use `starry join` flow from an account that *doesn't* have the added token, expect no roles when finished
- [ ] Use `starry join` flow from an account that *does* have the added token, expect all applicable roles to be added

### Further QA:

- [ ] In the middle of a wizard, click on a button from another step, expect a helpful error or it to be ignored
- [ ] Reply to messages that are expecting emoji reaction inputs
- [ ] Kick starrybot (not farewell) and re-add, ensuring normal functioning
