### PR TITLE
Infer native token

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -227,6 +227,16 @@ const memberExists = async (uuid, guildId) => {
 	}).select('id')
 }
 
+const inferPreferredNativeToken = async (guildId) => {
+	await ensureDatabaseInitialized()
+	let nativeTokens = await knex(myConfig.DB_TABLENAME_ROLES)
+		.where('discord_guild_id', guildId)
+		.andWhere('token_type', 'native')
+		.select('token_address' )
+		.orderBy('created_at', 'desc')
+	return (nativeTokens && nativeTokens.length) ? nativeTokens[0]['token_address'] : false
+}
+
 const memberBySessionToken = async (session_token) => {
 	await ensureDatabaseInitialized()
 	let members = await knex(myConfig.DB_TABLENAME_MEMBERS)
@@ -266,4 +276,4 @@ const memberDelete = async ({authorId, guildId}) => {
 	}
 }
 
-module.exports = { membersAll, memberExists, memberBySessionToken, memberByIdAndGuild, memberAdd, memberDelete, myConfig, rolesGet, roleGet, rolesSet, rolesDelete, rolesDeleteGuildAll, rolesGetForCleanUp }
+module.exports = { membersAll, memberExists, memberBySessionToken, memberByIdAndGuild, memberAdd, memberDelete, myConfig, rolesGet, roleGet, rolesSet, rolesDelete, rolesDeleteGuildAll, rolesGetForCleanUp, inferPreferredNativeToken }

--- a/src/logic.js
+++ b/src/logic.js
@@ -44,6 +44,7 @@ async function hoistRequest(args) {
 
 // Allow a remote caller to inquire about a member
 async function hoistInquire(traveller) {
+	let ret
 	// If they didn't send the proper parameter
 	if (!traveller) {
 		throw "No traveller sent"
@@ -60,7 +61,15 @@ async function hoistInquire(traveller) {
 
 	const saganism = member.saganism
 
-	return {saganism, createdAt}
+	ret = { saganism, createdAt }
+	// See if we can determine a preferred native token, informing which
+	// chain ID the frontend should try to connect
+	const preferredPrefix = await db.inferPreferredNativeToken(member.discord_guild_id)
+	if (preferredPrefix) {
+		ret.nativeToken = preferredPrefix
+	}
+
+	return ret
 }
 
 // And drop a user


### PR DESCRIPTION
Addresses https://github.com/starryzone/cosmos-webapp/pull/5

### Description:

When the frontend fetches `/starry-backend` we'll also grab (if it exists) the latest native token rule they have, and give them the token address, such as "juno"

This allows the frontend, in the PR linked above, to change which chain Keplr will use when signing.

### Suggested QA:

- [ ] Use `/starry farewell` to remove bot, ensure that created roles have been removed
- [ ] Re-add the bot, expect a welcome message
- [ ] Use `/starry token-rule add` normally
  - [ ] Select "Choose a token" normally
  - [ ] Select "I need to make a token" normally
  - [ ] Select the DAODAO option normally
- [ ] Use `/starry token-rule add` incorrectly, expect helpful error
  - [ ] For the first two options, enter invalid cw20 address
  - [ ] For DAODAO option, type in an incorrect URL
- [ ] Use `starry join` flow from an account that *doesn't* have the added token, expect no roles when finished
- [ ] Use `starry join` flow from an account that *does* have the added token, expect all applicable roles to be added

### Further QA:

- [ ] In the middle of a wizard, click on a button from another step, expect a helpful error or it to be ignored
- [ ] Reply to messages that are expecting emoji reaction inputs
- [ ] Kick starrybot (not farewell) and re-add, ensuring normal functioning
