### PR TITLE
Reregister commands for guilds on bot restart as needed

### DIFF
--- a/src/discord.js
+++ b/src/discord.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { REST } = require('@discordjs/rest');
+const { Routes } = require('discord-api-types/v9');
 const { Client, Collection, Intents } = require('discord.js')
 
 const db = require("./db")
@@ -28,7 +30,85 @@ client.commands.set(starryCommand.data.name, starryCommand);
 ///
 
 // Handler for discord bot server starting
-client.on("ready", async () => { logger.info(`starrybot has star(ry)ted.`) });
+client.on("ready", async (client) => {
+  logger.info(`starrybot has star(ry)ted.`);
+
+  // Now that the bot has restarted, see if any guilds using us
+  // needs to pick up an updated version of the application commands
+
+  let updatedGuilds = 0;
+  let skippedGuilds = 0;
+  let erroredGuilds = 0;
+
+  // Get the latest description of our starry commands for comparison.
+  // Discord deletes the "option" property if it's just an
+  // empty array, but our toJSON always has them set. We do
+  // a naive JSON.stringify comparison below, so delete them here
+  const updatedStarry = starryCommand.data.toJSON();
+  updatedStarry.options.forEach((opt) => {
+    if (opt.options) {
+      if (opt.options.length === 0) {
+        delete opt.options;
+      } else {
+        opt.options.forEach((subOpt) => {
+          // We don't have more than 2 layers today, but just in case..
+          if (subOpt.options && subOpt.options.length === 0) {
+            delete subOpt.options;
+          }
+        });
+      }
+    }
+  });
+
+  const rest = new REST().setToken(db.myConfig.DISCORD_TOKEN);
+  // Loop through all guilds that are registered with us
+  client.guilds.cache.forEach(async (guild) => {
+    try {
+      // Get the application commands currently registered with this guild
+      const currentCommands = await rest.get(
+        Routes.applicationGuildCommands(client.application.id, guild.id)
+      );
+      const currentStarry = currentCommands.find(
+        (command) => command.name === updatedStarry.name
+      );
+
+      // Determine if this guild needs updating
+      const needsUpdate =
+        // ??? where is our command?
+        !currentStarry ||
+        // We updated the description
+        currentStarry.description !== updatedStarry.description ||
+        // We have a different number of options
+        currentStarry.options.length !== updatedStarry.options.length ||
+        // At least one of the options is now different
+        updatedStarry.options.some((updatedOpt) => {
+          const currentOpt = currentStarry.options.find(
+            (curOpt) => curOpt.name === updatedOpt.name
+          );
+          return JSON.stringify(updatedOpt) !== JSON.stringify(currentOpt);
+        });
+
+      if (needsUpdate) {
+        // The commands need updating, do it for them <3
+        await rest.put(
+          Routes.applicationGuildCommands(client.application.id, guild.id),
+          { body: [starryCommand.data.toJSON()] }
+        );
+        updatedGuilds += 1;
+      } else {
+        skippedGuilds += 1;
+      }
+    } catch (e) {
+      console.warn(e);
+      erroredGuilds += 1;
+    }
+
+    // Not sure how valuable this is, but could be interesting
+    if (updatedGuilds > 0) console.log(`Updated commands for ${updatedGuilds} guild(s)`)
+    if (skippedGuilds > 0) console.log(`Skipped update for ${skippedGuilds} guild(s)`)
+    if (erroredGuilds > 0) console.log(`Failed to update ${erroredGuilds} guild(s)`);
+  });
+});
 
 // Handler for discord bot joining a server
 client.on("guildCreate", guildCreate);


### PR DESCRIPTION
```
The bot currently only registers guild commands on guildCreate,
which is the event used when a bot is first added to a guild. This
inadvertently meant that users of starrybot could not get any of
the recent slash command updates unless they kicked and re-added
the bot.

Now, when the bot has successfully started, we'll try and see if
we can helpfully re-register guild commands for any of the guilds
registered with our client. If there are no differences detected
between their registered commands and our latest starry commands,
nothing will happen.
```

Testing steps that should work locally:

* Commenting out a command (should disappear after bot restart)
* Commenting out a subcommand (should disappear after bot restart)
* Renaming a command or subcommand (should be updated after bot restart)
* Changing the description for a command or subcommand (should be updated after bot restart)

I didn't check for command/subcommand order as a reason for update as of this branch since the discord command menu has it's own ordering anyways, but it should be easy to update this logic as needed later

### Suggested QA:

- [ ] Use `/starry farewell` to remove bot, ensure that created roles have been removed
- [ ] Re-add the bot, expect a welcome message
- [ ] Use `/starry token-rule add` normally
  - [ ] Select "Choose a token" normally
  - [ ] Select "I need to make a token" normally
  - [ ] Select the DAODAO option normally
- [ ] Use `/starry token-rule add` incorrectly, expect helpful error
  - [ ] For the first two options, enter invalid cw20 address
  - [ ] For DAODAO option, type in an incorrect URL
- [ ] Use `starry join` flow from an account that *doesn't* have the added token, expect no roles when finished
- [ ] Use `starry join` flow from an account that *does* have the added token, expect all applicable roles to be added

### Further QA:

- [ ] In the middle of a wizard, click on a button from another step, expect a helpful error or it to be ignored
- [ ] Reply to messages that are expecting emoji reaction inputs
- [ ] Kick starrybot (not farewell) and re-add, ensuring normal functioning
