### PR TITLE
Initialize new cw721 file to support future changes

### DIFF
--- a/src/astrolabe/index.js
+++ b/src/astrolabe/index.js
@@ -1,9 +1,13 @@
 const { cw20 } = require('./tokens/cw20');
+const { cw721 } = require('./tokens/cw721');
 const { native } = require('./tokens/native');
 
 // cw20 must be last right now, as the others are
 // easier to check for
-const allTokenTypes = [ native, cw20 ];
+// @to-do 🚧: move cw721 in front of cw20 when we've identified
+// how to recognize an address is for a collection instead
+// of a cw20
+const allTokenTypes = [ native, cw20, cw721 ];
 
 // Given any of a DAODAO URL, CW20 token address, or a native token,
 // return the handler for that token type

--- a/src/astrolabe/tokens/cw721.js
+++ b/src/astrolabe/tokens/cw721.js
@@ -1,0 +1,30 @@
+const { CosmWasmClient } = require("@cosmjs/cosmwasm-stargate");
+
+const getCW721TokenDetails = async (userInput) => {
+  // Given the address of an NFT collection,
+  // Fill out the following correctly
+  return {
+    network: null,
+    tokenType: 'cw721',
+    tokenSymbol: null,
+    decimals: null, // keep null
+  }
+}
+
+const getCW721TokenBalance = async (keplrAccount, tokenAddress, network) => {
+  // Given the wallet address, NFT collection address,
+  // and the network it's on, do the math for the following correctly
+
+  // Return the # of NFTs this user has from this wallet
+  return parseInt(1);
+}
+
+module.exports = {
+  cw721: {
+    name: 'CW721',
+    // TO-DO: How can we tell if a token address is for an NFT?
+    isTokenType: () => true,
+    getTokenBalance: getCW721TokenBalance,
+    getTokenDetails: getCW721TokenDetails,
+  }
+}


### PR DESCRIPTION
### Description:

Minimal change to initialize this file to avoid merge conflicts - the two tasks we both plan on doing should effectively fill out of the new functions.

### Suggested QA:

- [ ] Use `/starry farewell` to remove bot, ensure that created roles have been removed
- [ ] Re-add the bot, expect a welcome message
- [ ] Use `/starry token-rule add` normally
  - [ ] Select "Choose a token" normally
  - [ ] Select "I need to make a token" normally
  - [ ] Select the DAODAO option normally
- [ ] Use `/starry token-rule add` incorrectly, expect helpful error
  - [ ] For the first two options, enter invalid cw20 address
  - [ ] For DAODAO option, type in an incorrect URL
- [ ] Use `starry join` flow from an account that *doesn't* have the added token, expect no roles when finished
- [ ] Use `starry join` flow from an account that *does* have the added token, expect all applicable roles to be added

### Further QA:

- [ ] In the middle of a wizard, click on a button from another step, expect a helpful error or it to be ignored
- [ ] Reply to messages that are expecting emoji reaction inputs
- [ ] Kick starrybot (not farewell) and re-add, ensuring normal functioning
