### PR TITLE
Migration for cosmos address, add address after verification

### DIFF
--- a/migrations/20220320171620_add_cosmos_address_col.js
+++ b/migrations/20220320171620_add_cosmos_address_col.js
@@ -1,0 +1,15 @@
+const path = require("path");
+const dbPath = path.join(__dirname, '../src/db.js');
+const { myConfig } = require(dbPath);
+
+exports.up = function(knex) {
+  return knex.schema.table(myConfig.DB_TABLENAME_MEMBERS, function(table) {
+    table.string('cosmos_address')
+  })
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(myConfig.DB_TABLENAME_MEMBERS, function(table) {
+    table.dropColumn('cosmos_address')
+  })
+};

--- a/src/db.js
+++ b/src/db.js
@@ -276,4 +276,13 @@ const memberDelete = async ({authorId, guildId}) => {
 	}
 }
 
-module.exports = { membersAll, memberExists, memberBySessionToken, memberByIdAndGuild, memberAdd, memberDelete, myConfig, rolesGet, roleGet, rolesSet, rolesDelete, rolesDeleteGuildAll, rolesGetForCleanUp, inferPreferredNativeToken }
+const addCosmosHubAddress = async (guildId, discordAccountId, cosmosHubAddress) => {
+	await knex(myConfig.DB_TABLENAME_MEMBERS)
+		.where({
+			'discord_guild_id': guildId,
+			'discord_account_id': discordAccountId
+		})
+		.update('cosmos_address', cosmosHubAddress)
+}
+
+module.exports = { membersAll, memberExists, memberBySessionToken, memberByIdAndGuild, memberAdd, memberDelete, myConfig, rolesGet, roleGet, rolesSet, rolesDelete, rolesDeleteGuildAll, rolesGetForCleanUp, inferPreferredNativeToken, addCosmosHubAddress }

--- a/src/logic.js
+++ b/src/logic.js
@@ -6,7 +6,7 @@ const Sagan = require("./sagan.js")
 
 const { serializeSignDoc } = require('@cosmjs/amino')
 const { Secp256k1, Secp256k1Signature, sha256 } = require('@cosmjs/crypto')
-const { fromBase64 } = require('@cosmjs/encoding')
+const { fromBase64, Bech32} = require('@cosmjs/encoding')
 const { REST } = require("@discordjs/rest");
 const { Routes } = require("discord-api-types/v9");
 const { getTokenBalance } = require("./astrolabe");
@@ -125,7 +125,7 @@ const isCorrectSaganism = async (traveller, signed) => {
 
 // Finalize hoist
 async function hoistFinalize(blob, client) {
-	const {traveller, signed, signature, account} = blob;
+	const { traveller, signed, signature, account } = blob;
 	const publicKey = account.pubkey
 
 	// get member
@@ -161,6 +161,10 @@ async function hoistFinalize(blob, client) {
 	}
 
 	logger.log("*** user has passed all tests *** ")
+	// Add the user's Cosmos Hub address to database
+	// Convert to Cosmos Hub address
+	let cosmosHubAddress = Bech32.encode('cosmos', Bech32.decode(account.address).data)
+	await db.addCosmosHubAddress(member.discord_guild_id, member.discord_account_id, cosmosHubAddress)
 
 	// get all possible roles
 	let roles = await db.rolesGet(member.discord_guild_id)


### PR DESCRIPTION
### Description:

Adds column to the members table so we can keep track of the relationship between the Discord user ID (w/ guild) and their Cosmos address. Since the offline signing is smart and doesn't require you to be on any particular network, I think it makes sense to use their Cosmos Hub address to keep things consistent.

We can discuss improving this a bit by perhaps having a pivot table where the Discord user ID and the Token Rule have a more explicit relationship. This PR is the first step toward capturing information, and we can glean good airdrop info by looking at the roles for a particular user, but perhaps there's a database enhancement we could make in the future.

No matter what, we want to start capturing the user addresses as starry as possible.

## Running

Remember to run 😉 :

    ./node_modules/.bin/knex migrate:latest

### Suggested QA:

- [ ] Use `/starry farewell` to remove bot, ensure that created roles have been removed
- [ ] Re-add the bot, expect a welcome message
- [ ] Use `/starry token-rule add` normally
  - [ ] Select "Choose a token" normally
  - [ ] Select "I need to make a token" normally
  - [ ] Select the DAODAO option normally
- [ ] Use `/starry token-rule add` incorrectly, expect helpful error
  - [ ] For the first two options, enter invalid cw20 address
  - [ ] For DAODAO option, type in an incorrect URL
- [ ] Use `starry join` flow from an account that *doesn't* have the added token, expect no roles when finished
- [ ] Use `starry join` flow from an account that *does* have the added token, expect all applicable roles to be added

### Further QA:

- [ ] In the middle of a wizard, click on a button from another step, expect a helpful error or it to be ignored
- [ ] Reply to messages that are expecting emoji reaction inputs
- [ ] Kick starrybot (not farewell) and re-add, ensuring normal functioning
