### PR TITLE
check for wizardware object in call to end function

### DIFF
--- a/src/wizardware/wizard.js
+++ b/src/wizardware/wizard.js
@@ -89,7 +89,7 @@ class Wizard {
   }
 
   async end() {
-    if (this) {
+    if (this && this.wizardware) {
       this.wizardware.end(this.uniqueKey);
     }
   }


### PR DESCRIPTION
### Description:

We saw this interesting thing in the Render logs and wanted to address it:

<img width="796" alt="Screen Shot 2022-04-10 at 1 42 06 PM" src="https://user-images.githubusercontent.com/1042667/162639247-82b24590-c5db-4ff0-98dc-9baed1c05543.png">


### Suggested QA:

- [ ] Use `/starry farewell` to remove bot, ensure that created roles have been removed
- [ ] Re-add the bot, expect a welcome message
- [ ] Use `/starry token-rule add` normally
  - [ ] Select "Choose a token" normally
  - [ ] Select "I need to make a token" normally
  - [ ] Select the DAODAO option normally
- [ ] Use `/starry token-rule add` incorrectly, expect helpful error
  - [ ] For the first two options, enter invalid cw20 address
  - [ ] For DAODAO option, type in an incorrect URL
- [ ] Use `starry join` flow from an account that *doesn't* have the added token, expect no roles when finished
- [ ] Use `starry join` flow from an account that *does* have the added token, expect all applicable roles to be added

### Further QA:

- [ ] In the middle of a wizard, click on a button from another step, expect a helpful error or it to be ignored
- [ ] Reply to messages that are expecting emoji reaction inputs
- [ ] Kick starrybot (not farewell) and re-add, ensuring normal functioning
