### PR TITLE
Replace onError abstraction, fix auth check

### DIFF
--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -7,7 +7,6 @@ const { starryCommandTokenEdit } = require('./tokenEdit');
 const { starryCommandTokenRemove } = require('./tokenRemove');
 
 const { buildCommandData } = require('../utils/commands');
-const { createPrivateError } = require("../utils/messages");
 const { Wizardware } = require("../wizardware");
 
 // Useful dependencies to inject through the steps
@@ -19,8 +18,6 @@ const networks = require("../astrolabe/networks");
 const stargaze = require("../astrolabe/stargaze");
 
 const wizardware = new Wizardware({
-  // How we want errors thrown by the wizard to be handled
-  onError: createPrivateError,
 
   // Dependencies that each step should have access to
   dependencies: {

--- a/src/wizardware/index.js
+++ b/src/wizardware/index.js
@@ -7,15 +7,9 @@ class Wizardware {
 
   registeredSteps = new Map();
 
-  onError;
-
   timeoutDuration = 360000;
 
-  constructor({ dependencies, onError, timeoutDuration }) {
-    if (onError) {
-      this.onError = onError;
-    }
-
+  constructor({ dependencies, timeoutDuration }) {
     if (dependencies) {
       this.dependencies = Object.assign(this.dependencies, dependencies);
     }
@@ -48,11 +42,6 @@ class Wizardware {
 
   async end (uniqueKey) {
     this.activeWizards.delete(uniqueKey);
-  }
-
-  async error (uniqueKey, errorMessage) {
-    await this.onError(errorMessage);
-    await this.end(uniqueKey);
   }
 }
 


### PR DESCRIPTION
```
- The wizardware.onError pattern was accepting a function
  for error message creation, but then never actually sending
  the message. This abstraction might be a bit early anyways
  so it's now been removed in favor of a discord-reliant
  but more literal error handling in the wizard.
- The wizard auth checking was naively logging a console
  warning about invalid permissions and then allowing them
  to continue the chain anyways. This has been fixed to be
  less amateurish 😅
```

### Description:

tl;dr non-admins shouldn't be able to use admin commands anymore and the bot says why again

### Suggested QA:

- [ ] Use `/starry farewell` to remove bot, ensure that created roles have been removed
- [ ] Re-add the bot, expect a welcome message
- [ ] Use `/starry token-rule add` normally
  - [ ] Select "Choose a token" normally
  - [ ] Select "I need to make a token" normally
  - [ ] Select the DAODAO option normally
- [ ] Use `/starry token-rule add` incorrectly, expect helpful error
  - [ ] For the first two options, enter invalid cw20 address
  - [ ] For DAODAO option, type in an incorrect URL
- [ ] Use `starry join` flow from an account that *doesn't* have the added token, expect no roles when finished
- [ ] Use `starry join` flow from an account that *does* have the added token, expect all applicable roles to be added

### Further QA:

- [ ] In the middle of a wizard, click on a button from another step, expect a helpful error or it to be ignored
- [ ] Reply to messages that are expecting emoji reaction inputs
- [ ] Kick starrybot (not farewell) and re-add, ensuring normal functioning
