### PR TITLE
ensure that any reaction to reaction prompt won't crash

### DIFF
--- a/src/utils/commands.js
+++ b/src/utils/commands.js
@@ -67,7 +67,8 @@ function buildCommandExecute(command) {
             const emojiName = reaction?._emoji?.name;
             if(!emojiName) return;
             else {
-              return config.prompt.options.find(emojiConfig => emojiConfig.emoji === emojiName).next;
+              const option = config.prompt.options.find(emojiConfig => emojiConfig.emoji === emojiName)
+              if (option) return option.next
             }
           }
 


### PR DESCRIPTION
Fixes #93 

### Description:
It looks like reaction management was somewhat assuming that the reaction to a message would be a valid one of the subset. But if a user added a random emoji, it would try to call the `next` function/object/whatever that wasn't there.

### Suggested QA:

- [ ] Use `/starry farewell` to remove bot, ensure that created roles have been removed
- [ ] Re-add the bot, expect a welcome message
- [ ] Use `/starry token-rule add` normally
  - [ ] Select "Choose a token" normally
  - [ ] Select "I need to make a token" normally
  - [ ] Select the DAODAO option normally
- [ ] Use `/starry token-rule add` incorrectly, expect helpful error
  - [ ] For the first two options, enter invalid cw20 address
  - [ ] For DAODAO option, type in an incorrect URL
- [ ] Use `starry join` flow from an account that *doesn't* have the added token, expect no roles when finished
- [ ] Use `starry join` flow from an account that *does* have the added token, expect all applicable roles to be added

### Further QA:

- [ ] In the middle of a wizard, click on a button from another step, expect a helpful error or it to be ignored
- [ ] Reply to messages that are expecting emoji reaction inputs
- [ ] Kick starrybot (not farewell) and re-add, ensuring normal functioning
