### PR TITLE
add parseInt early for token add + edit flows

### DIFF
--- a/src/commands/tokenAdd/promptTokenAmount.js
+++ b/src/commands/tokenAdd/promptTokenAmount.js
@@ -1,11 +1,12 @@
 module.exports = {
   promptTokenAmount: {
     getConfig: async (state) => {
-      let { userInput: amountOfTokensNeeded } = state;
+      let { userInput } = state;
 
+      let amountOfTokensNeeded = parseInt(userInput)
       // TODO: add fix so they can enter .1 instead of 0.1 and have it work
       if (
-        !Number.isInteger(parseInt(amountOfTokensNeeded)) ||
+        !Number.isInteger(amountOfTokensNeeded) ||
         amountOfTokensNeeded <= 0
       ) {
         // Invalid reply

--- a/src/commands/tokenEdit/handleRoleAmountEdit.js
+++ b/src/commands/tokenEdit/handleRoleAmountEdit.js
@@ -4,7 +4,7 @@ module.exports = {
       {
         userId,
         guildId,
-        userInput: amountOfTokensNeeded,
+        userInput,
         selectedRoleName,
         selectedRole: { decimals, network, token_address, token_type, staking_contract, count_staked_only }
       },
@@ -12,8 +12,10 @@ module.exports = {
         db: { rolesSet }
       }
     ) => {
+      let amountOfTokensNeeded = parseInt(userInput)
+      console.log('aloha parseInt(amountOfTokensNeeded)', amountOfTokensNeeded)
       if (
-        !Number.isInteger(parseInt(amountOfTokensNeeded)) ||
+        !Number.isInteger(amountOfTokensNeeded) ||
         amountOfTokensNeeded <= 0
       ) {
         // Invalid reply


### PR DESCRIPTION
### Description:

There was an issue where when the bot asked for the number of tokens, you could enter:

    6'

and it would get confused, eventually making it into the database as `NaN` or "not a number"

We just had to do some light rework on how `parseInt` was being used. This applied for new token rules as well as edited ones.

### Suggested QA:

- [ ] Use `/starry farewell` to remove bot, ensure that created roles have been removed
- [ ] Re-add the bot, expect a welcome message
- [ ] Use `/starry token-rule add` normally
  - [ ] Select "Choose a token" normally
  - [ ] Select "I need to make a token" normally
  - [ ] Select the DAODAO option normally
- [ ] Use `/starry token-rule add` incorrectly, expect helpful error
  - [ ] For the first two options, enter invalid cw20 address
  - [ ] For DAODAO option, type in an incorrect URL
- [ ] Use `starry join` flow from an account that *doesn't* have the added token, expect no roles when finished
- [ ] Use `starry join` flow from an account that *does* have the added token, expect all applicable roles to be added

### Further QA:

- [ ] In the middle of a wizard, click on a button from another step, expect a helpful error or it to be ignored
- [ ] Reply to messages that are expecting emoji reaction inputs
- [ ] Kick starrybot (not farewell) and re-add, ensuring normal functioning
