### PR TITLE
if no systemChannelId, create or use existing starrybot channel

### DIFF
--- a/src/handlers/guildCreate.js
+++ b/src/handlers/guildCreate.js
@@ -30,8 +30,20 @@ async function registerGuildCommands(appId, guildId) {
 
 // When starrybot joins a new guild, let's say hello and let them know they can use /starry now
 async function guildCreate(guild) {
-  const systemChannelId = guild.systemChannelId;
+  let systemChannelId = guild.systemChannelId;
   const { client } = guild;
+  if (systemChannelId === null) {
+    // Create a "starrybot" channel or get it
+    let existingStarryBotChannel = client.channels.cache.find(c => c.name === 'starrybot');
+    if (existingStarryBotChannel) {
+      systemChannelId = existingStarryBotChannel.id
+    } else {
+      // Did not find an existing channel, create one
+      const creationRes = await guild.channels.create('starrybot')
+      systemChannelId = creationRes.id
+    }
+  }
+
   let systemChannel = await client.channels.fetch(systemChannelId);
   try {
     await registerGuildCommands(client.application.id, guild.id);


### PR DESCRIPTION
Fixes some nice person named desu reported that if you deleted the general channel and then tried to add the bot, there were problems.

### Description:

### Suggested QA:

- [ ] Use `/starry farewell` to remove bot, ensure that created roles have been removed
- [ ] Re-add the bot, expect a welcome message
- [ ] Use `/starry token-rule add` normally
  - [ ] Select "Choose a token" normally
  - [ ] Select "I need to make a token" normally
  - [ ] Select the DAODAO option normally
- [ ] Use `/starry token-rule add` incorrectly, expect helpful error
  - [ ] For the first two options, enter invalid cw20 address
  - [ ] For DAODAO option, type in an incorrect URL
- [ ] Use `starry join` flow from an account that *doesn't* have the added token, expect no roles when finished
- [ ] Use `starry join` flow from an account that *does* have the added token, expect all applicable roles to be added

### Further QA:

- [ ] In the middle of a wizard, click on a button from another step, expect a helpful error or it to be ignored
- [ ] Reply to messages that are expecting emoji reaction inputs
- [ ] Kick starrybot (not farewell) and re-add, ensuring normal functioning
