### PR TITLE
addRemoveRoles no longer sends message to systemChannel

### DIFF
--- a/src/logic.js
+++ b/src/logic.js
@@ -198,13 +198,13 @@ async function addRemoveRoles(discordUserId, discordGuildId, cosmosAddress, clie
     }
 
     // At this point, we're sure the user has given the role
-    const systemChannelId = guild.systemChannelId;
-    let systemChannel = await client.channels.fetch(systemChannelId);
     if (!roleDiscord) {
-      systemChannel.send("Hmm, starrybot cannot find role " + roleName)
+      logger.error('Could not find role', { data: {
+        roleName
+      }})
     } else {
       if (discordRole && !member.roles.cache.has(discordRole.id)) {
-        logger.log("Adding user to role " + roleName)
+        logger.log(`Adding user ${author.id} to role ${roleName}`)
         const rest = new REST().setToken(process.env.DISCORD_TOKEN);
         try {
           await rest.put(
@@ -212,8 +212,7 @@ async function addRemoveRoles(discordUserId, discordGuildId, cosmosAddress, clie
           );
           ret.added.push(roleName)
         } catch (e) {
-          console.error('Error trying to add role', e)
-          systemChannel.send("starrybot was unable to give someone their role :(\nPlease make sure my permission is higher in the list than " + roleDiscord.name);
+          logger.error('Error trying to add role', e)
           return;
         }
       } else {


### PR DESCRIPTION
### Description:

One to two members in our Discord reporting behavior having to do with verifying and getting a messed up signature. We're realizing more and more that the `systemChannelId` is finicky.

Since we don't need to send messages here anyway, we'll remove it and log instead, which is where we're headed anyhow.

### Suggested QA:

- [ ] Use `/starry farewell` to remove bot, ensure that created roles have been removed
- [ ] Re-add the bot, expect a welcome message
- [ ] Use `/starry token-rule add` normally
  - [ ] Select "Choose a token" normally
  - [ ] Select "I need to make a token" normally
  - [ ] Select the DAODAO option normally
- [ ] Use `/starry token-rule add` incorrectly, expect helpful error
  - [ ] For the first two options, enter invalid cw20 address
  - [ ] For DAODAO option, type in an incorrect URL
- [ ] Use `starry join` flow from an account that *doesn't* have the added token, expect no roles when finished
- [ ] Use `starry join` flow from an account that *does* have the added token, expect all applicable roles to be added

### Further QA:

- [ ] In the middle of a wizard, click on a button from another step, expect a helpful error or it to be ignored
- [ ] Reply to messages that are expecting emoji reaction inputs
- [ ] Kick starrybot (not farewell) and re-add, ensuring normal functioning
