### PR TITLE
add ephemeral key to a few commands

### DIFF
--- a/src/commands/farewell/farewellConfirmation.js
+++ b/src/commands/farewell/farewellConfirmation.js
@@ -25,7 +25,7 @@ module.exports = {
       await rolesDeleteGuildAll(guildId)
 
       // confirm
-      await interaction.reply('Bye!')
+      await interaction.reply({content: 'Bye!', ephemeral: true})
 
       // leave
       await interaction.guild.leave()

--- a/src/commands/farewell/farewellRejection.js
+++ b/src/commands/farewell/farewellRejection.js
@@ -1,5 +1,6 @@
 module.exports = {
   farewellRejection: {
     message: '✨ 👍 🌟',
+    ephemeral: true
   }
 }

--- a/src/commands/farewell/index.js
+++ b/src/commands/farewell/index.js
@@ -4,6 +4,7 @@ const { farewellRejection } = require('./farewellRejection');
 module.exports = {
   starryCommandFarewell: {
     adminOnly: true,
+    ephemeral: true,
     name: 'farewell',
     description: 'Kick starrybot itself from your guild',
     prompt: {

--- a/src/commands/tokenList/index.js
+++ b/src/commands/tokenList/index.js
@@ -14,6 +14,7 @@ module.exports = {
           }).join('')}` :
         `This will be way more exciting when roles are added :)`;
       return {
+        ephemeral: true,
         done: { title, description }
       };
     }

--- a/src/utils/commands.js
+++ b/src/utils/commands.js
@@ -43,7 +43,8 @@ function buildCommandExecute(command) {
                 description: 'Loading choices, fren.',
               }],
               // Necessary in order to react to the message
-              fetchReply: true
+              fetchReply: true,
+              ephemeral: config.ephemeral
             })
           );
 
@@ -61,6 +62,7 @@ function buildCommandExecute(command) {
               }
             ],
             title: config.title,
+            ephemeral: config.ephemeral
           }));
 
           const getNextCommandNameFromEmoji = ({ reaction }) => {


### PR DESCRIPTION
Fixes #

### Description:

### Suggested QA:

- [ ] Use `/starry farewell` to remove bot, ensure that created roles have been removed
- [ ] Re-add the bot, expect a welcome message
- [ ] Use `/starry token-rule add` normally
  - [ ] Select "Choose a token" normally
  - [ ] Select "I need to make a token" normally
  - [ ] Select the DAODAO option normally
- [ ] Use `/starry token-rule add` incorrectly, expect helpful error
  - [ ] For the first two options, enter invalid cw20 address
  - [ ] For DAODAO option, type in an incorrect URL
- [ ] Use `starry join` flow from an account that *doesn't* have the added token, expect no roles when finished
- [ ] Use `starry join` flow from an account that *does* have the added token, expect all applicable roles to be added

### Further QA:

- [ ] In the middle of a wizard, click on a button from another step, expect a helpful error or it to be ignored
- [ ] Reply to messages that are expecting emoji reaction inputs
- [ ] Kick starrybot (not farewell) and re-add, ensuring normal functioning
