### PR TITLE
add /metrics endpoint and query returning total guilds, roles, and me…

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -278,6 +278,24 @@ const memberAdd = async ({discord_account_id, discord_guild_id, saganism}) => {
 	return session_token
 }
 
+const metrics = async() => {
+	let totalGuilds = await knex(myConfig.DB_TABLENAME_ROLES).countDistinct('discord_guild_id')
+	totalGuilds = parseInt(totalGuilds[0].count)
+	let totalRoles = {}
+	for (const tokenType of ['native', 'cw20', 'cw721']) {
+		const tokenCount = await knex(myConfig.DB_TABLENAME_ROLES).where('token_type', tokenType).count('*')
+		totalRoles[tokenType] = parseInt(tokenCount[0].count)
+	}
+	let totalMembers = await knex(myConfig.DB_TABLENAME_MEMBERS).whereNotNull('cosmos_address').countDistinct('cosmos_address')
+	totalMembers = parseInt(totalMembers[0].count)
+
+	return {
+		totalGuilds,
+		totalRoles,
+		totalMembers
+	}
+}
+
 const memberDelete = async ({authorId, guildId}) => {
 	await ensureDatabaseInitialized()
 	try {
@@ -308,4 +326,4 @@ const getCosmosHubAddress = async ({guildId, discordUserId}) => {
 	return cosmosHubAddresses[0].cosmos_address
 }
 
-module.exports = { membersAll, memberExists, memberBySessionToken, memberByIdAndGuild, memberAdd, memberDelete, myConfig, rolesGet, roleGet, rolesSet, rolesDelete, rolesDeleteGuildAll, rolesGetForCleanUp, inferPreferredNativeToken, addCosmosHubAddress, nativeTokensFromGuild, getCosmosHubAddress, syncDetails }
+module.exports = { membersAll, memberExists, memberBySessionToken, memberByIdAndGuild, memberAdd, memberDelete, myConfig, rolesGet, roleGet, rolesSet, rolesDelete, rolesDeleteGuildAll, rolesGetForCleanUp, inferPreferredNativeToken, addCosmosHubAddress, nativeTokensFromGuild, getCosmosHubAddress, syncDetails, metrics }

--- a/src/server.js
+++ b/src/server.js
@@ -57,6 +57,11 @@ app.get('/health-check', async (req, res) => {
   res.status(200).send()
 })
 
+app.get('/metrics', async (req, res) => {
+  const metrics = await db.metrics()
+  res.status(200).send(metrics)
+})
+
 // TODO arguably config could be separate from db so that db would not need to be included here
 const PORT = db.myConfig.PORT || process.env.PORT || 80;
 const server = app.listen(PORT, () => {


### PR DESCRIPTION
…mbers

Fixes #

### Description:

### Suggested QA:

- [ ] Use `/starry farewell` to remove bot, ensure that created roles have been removed
- [ ] Re-add the bot, expect a welcome message
- [ ] Use `/starry token-rule add` normally
  - [ ] Select "Choose a token" normally
  - [ ] Select "I need to make a token" normally
  - [ ] Select the DAODAO option normally
- [ ] Use `/starry token-rule add` incorrectly, expect helpful error
  - [ ] For the first two options, enter invalid cw20 address
  - [ ] For DAODAO option, type in an incorrect URL
- [ ] Use `starry join` flow from an account that *doesn't* have the added token, expect no roles when finished
- [ ] Use `starry join` flow from an account that *does* have the added token, expect all applicable roles to be added

### Further QA:

- [ ] In the middle of a wizard, click on a button from another step, expect a helpful error or it to be ignored
- [ ] Reply to messages that are expecting emoji reaction inputs
- [ ] Kick starrybot (not farewell) and re-add, ensuring normal functioning
