### PR TITLE
Update stargaze CW721 handling

### DIFF
--- a/src/astrolabe/stargaze.js
+++ b/src/astrolabe/stargaze.js
@@ -2,14 +2,17 @@ const { CosmWasmClient } = require("@cosmjs/cosmwasm-stargate");
 const { getConnectionFromToken } = require('./networks')
 
 // Check to see if they pasted a Stargaze Launchpad URL like this:
-// https://app.stargaze.zone/launchpad/stars1m95chyen8tqrawmjhxrewcwscg5vj8pkxzxeaw8em7fnjwth8rusaftwk4
+// https://www.stargaze.zone/launchpad/stars1rkgf7w2cvy7q9rxsu3nsg7hy3gq79vyhmft8gf689fngnlrk8h5qytghmw
+// TO-DO: Ideally this shouldn't be hardcoded, as we've seen the
+// exact path here change before. It would be nice for this to be
+// provided by a library like cosmos-endpoints instead in the future.
 const isStargazeLaunchpadAddress = stargazeUrl => {
-  const stargazeLaunchpadRegex = /^https:\/\/app.stargaze.zone\/launchpad\/stars\w*/;
+  const stargazeLaunchpadRegex = /^https:\/\/(www|app).stargaze.zone\/launchpad\/stars\w*/;
   return stargazeUrl.match(stargazeLaunchpadRegex);
 }
 
 const getCW721FromStargazeLaunchpadUrl = async stargazeUrl => {
-  const stargazeLaunchpadRegex = /^https:\/\/app.stargaze.zone\/launchpad\/(stars\w*)/;
+  const stargazeLaunchpadRegex = /^https:\/\/(www|app).stargaze.zone\/launchpad\/(stars\w*)/;
   const regexMatches = stargazeLaunchpadRegex.exec(stargazeUrl);
   // [0] is the string itself, [1] is the (\w*) capture group
   const otherNftContract = regexMatches[1];


### PR DESCRIPTION
### Description:

> The stargaze launchpad URLs have changed slightly, causing
> our regular expression to no longer recognize them. This commit
> updates the regex to expect either the old or new pattern, just in case.

### Suggested QA:

- [ ] Use `/starry token-rule add` normally
  - [ ] Select "Cw721" token normally
  - [ ] Select "I have the Stargaze Launchpad URL"
  - [ ] Type a valid launchpad URL with www.* (e.g. https://www.stargaze.zone/launchpad/stars1lndsj2gufd292c35crv97ug2ncdcn9ys4s8e94wlxyeft6mt3k2svkwps9)
  - [ ] You should be able to successfully create a token role with the URL
- [ ] Repeat all the previous steps up until the launchpad URL
  - [ ] Type a valid launchpad URL with app.* (e.g. https://app.stargaze.zone/launchpad/stars1lndsj2gufd292c35crv97ug2ncdcn9ys4s8e94wlxyeft6mt3k2svkwps9)
