### PR TITLE
Support NFT role amounts, fix empty role bug

### DIFF
--- a/src/commands/tokenAdd/createTokenRule.js
+++ b/src/commands/tokenAdd/createTokenRule.js
@@ -9,6 +9,12 @@ module.exports = {
       // Required for every flow in token-rule add
       const selectedRoleName = state.interactionTarget.fields.getTextInputValue('role-name');
 
+      if (selectedRoleName.trim() === '') {
+        return {
+          error: 'Role Name cannot only be whitespace'
+        }
+      }
+
       let tokenAddress;
       if (state.tokenType !== 'native') {
         tokenAddress = state.interactionTarget.fields.getTextInputValue('token-address');
@@ -40,28 +46,22 @@ module.exports = {
 
       // This is set for native and cw20 only
       let amountOfTokensNeeded;
-      if (state.tokenType !== 'cw721') {
-        amountOfTokensNeeded = parseInt(state.interactionTarget.fields.getTextInputValue('token-amount'));
+      amountOfTokensNeeded = parseInt(state.interactionTarget.fields.getTextInputValue('token-amount'));
 
-        // TODO: add fix so they can enter .1 instead of 0.1 and have it work
-        if (
-          !Number.isInteger(amountOfTokensNeeded) ||
-          amountOfTokensNeeded <= 0
-        ) {
-          // Invalid reply
-          return {
-            error: 'Need a positive number of tokens.',
-          };
-        }
-
-        // Multiply by the decimals for native and fungible tokens
-        console.log('Multiplying by the number of decimals', state.decimals)
-        state.minimumTokensNeeded = amountOfTokensNeeded * (10 ** state.decimals)
-      } else {
-        // We don't currently prompt for how many NFTs someone should have
-        // to get a role
-        state.minimumTokensNeeded = 1;
+      // TODO: add fix so they can enter .1 instead of 0.1 and have it work
+      if (
+        !Number.isInteger(amountOfTokensNeeded) ||
+        amountOfTokensNeeded <= 0
+      ) {
+        // Invalid reply
+        return {
+          error: 'Need a positive number of tokens.',
+        };
       }
+
+      // Multiply by the decimals for native and fungible tokens
+      console.log('Multiplying by the number of decimals', state.decimals)
+      state.minimumTokensNeeded = amountOfTokensNeeded * (10 ** state.decimals)
       console.log('Minimum amount needed', state.minimumTokensNeeded)
 
       const { guild } = state

--- a/src/commands/tokenAdd/promptCW721.js
+++ b/src/commands/tokenAdd/promptCW721.js
@@ -8,6 +8,10 @@ module.exports = {
 
       return {
         next: 'createTokenRule',
+        stateOnEnter: {
+          tokenType: 'cw721',
+          decimals: 1,
+        },
         prompt: {
           type: 'modal',
           title: `Configure ${selectedOption} Token Rule`,
@@ -26,6 +30,12 @@ module.exports = {
               id: 'role-name',
               required: true,
             },
+            {
+              label: 'Token Amount',
+              placeholder: 'Please enter the number of tokens a user must have to get a special role',
+              id: 'token-amount',
+              required: true,
+            }
           ]
         }
       }

--- a/src/commands/tokenEdit/editRole.js
+++ b/src/commands/tokenEdit/editRole.js
@@ -23,13 +23,11 @@ module.exports = {
               placeholder: 'Current name: ' + selectedRoleName,
               id: 'role-name',
             },
-            // No need to prompt for token amount if the token role they're editing
-            // is for an NFT - right now we only support checking if they do or don't have one
-            ...(role.token_type !== 'cw721' ? [{
+            {
               label: 'New Token Amount',
               placeholder: 'Current amount needed: ' + (role.has_minimum_of / (10 ** role.decimals)),
               id: 'token-amount',
-            }] : []),
+            }
           ]
         }
       }

--- a/src/commands/tokenEdit/editRoleStakedOnly.js
+++ b/src/commands/tokenEdit/editRoleStakedOnly.js
@@ -18,22 +18,19 @@ module.exports = {
       state.newRoleName = newRoleName;
 
       // Validate token amount selection before continuing
-      // We only prompt token amount for native and CW20 tokens today
-      if (['native', 'cw20'].includes(selectedRole.token_type)) {
-        const amountOfTokensNeeded = parseInt(fields.getTextInputValue('token-amount'));
-        if (
-          !Number.isInteger(amountOfTokensNeeded) ||
-          amountOfTokensNeeded <= 0
-        ) {
-          // Invalid reply
-          return {
-            error: 'Need a positive number of tokens.'
-          }
+      const amountOfTokensNeeded = parseInt(fields.getTextInputValue('token-amount'));
+      if (
+        !Number.isInteger(amountOfTokensNeeded) ||
+        amountOfTokensNeeded <= 0
+      ) {
+        // Invalid reply
+        return {
+          error: 'Need a positive number of tokens.'
         }
-
-        // We'll multiply by the decimal before we update it
-        state.amountOfTokensNeeded = amountOfTokensNeeded;
       }
+
+      // We'll multiply by the decimal before we update it
+      state.amountOfTokensNeeded = amountOfTokensNeeded;
 
       return {
         next: 'handleRoleEdit',

--- a/src/commands/tokenEdit/handleRoleEdit.js
+++ b/src/commands/tokenEdit/handleRoleEdit.js
@@ -21,10 +21,9 @@ module.exports = {
       // If there was ultimately no change, we don't actually need to do anything.
       if (
         selectedRoleName === newRoleName &&
-        // Either this was a CW721 token role (which can't change the amount) or
-        // we need to also make sure we move the decimal points before comparing
+        // We need to also make sure we move the decimal points before comparing
         // with how much they asked to change
-        (token_type === 'cw721' || (has_minimum_of / (10 ** decimals)) === amountOfTokensNeeded) &&
+        (has_minimum_of / (10 ** decimals) === amountOfTokensNeeded) &&
         count_staked_only === updatedStakedOnly
       ) {
         return {
@@ -34,10 +33,7 @@ module.exports = {
         }
       }
 
-      // CW721 tokens currently cannot have token amounts changed
-      const updatedAmountOfTokensNeeded = token_type === 'cw721' ?
-        has_minimum_of :
-        amountOfTokensNeeded * (10 ** decimals);
+      const updatedAmountOfTokensNeeded = amountOfTokensNeeded * (10 ** decimals);
       
       // If the name has changed, we'll need to rename the role in discord, and then
       // replace the row in the DB altogether 
@@ -75,7 +71,7 @@ module.exports = {
       if (selectedRoleName !== newRoleName) {
         changes.push(`* Renamed from ${selectedRoleName} to ${newRoleName}`);
       }
-      if (token_type !== 'cw721' && amountOfTokensNeeded !== (has_minimum_of / (10 ** decimals))) {
+      if (amountOfTokensNeeded !== (has_minimum_of / (10 ** decimals))) {
         changes.push(`* Token minimum changed from ${has_minimum_of / (10 ** decimals)} to ${amountOfTokensNeeded}`);
       }
       if (count_staked_only !== updatedStakedOnly) {


### PR DESCRIPTION
### Description:

    Support NFT role amounts, fix empty role bug
    
    Previously we did not officially support CW721 token roles that
    checked for multiple NFTs. This has turned out to be a surprisingly
    popular usecase so it's time to make it official :D
    This means:
    - On token-rule add, the amount will always be visible now
    - On token-rule edit, we always allow amount to be editable, and
      properly validate the amount as the steps progress.
    - The calculation for multiple NFTs should work now that we've
      also manually updated the production NFT token-rules to all
      have the decimals set to 1 instead of null.

    Also make sure no one can create a role name that's just
    whitespace because that causes problems.

### Suggested QA:

- [ ] Use `/starry farewell` to remove bot, ensure that created roles have been removed
- [ ] Re-add the bot, expect a welcome message
- [ ] Use `/starry token-rule add` normally
  - [ ] Select "Choose a token" normally
  - [ ] Select "I need to make a token" normally
  - [ ] Select the DAODAO option normally
- [ ] Use `/starry token-rule add` incorrectly, expect helpful error
  - [ ] For the first two options, enter invalid cw20 address
  - [ ] For DAODAO option, type in an incorrect URL
- [ ] Use `starry join` flow from an account that *doesn't* have the added token, expect no roles when finished
- [ ] Use `starry join` flow from an account that *does* have the added token, expect all applicable roles to be added

### Further QA:

- [ ] In the middle of a wizard, click on a button from another step, expect a helpful error or it to be ignored
- [ ] Reply to messages that are expecting emoji reaction inputs
- [ ] Kick starrybot (not farewell) and re-add, ensuring normal functioning
